### PR TITLE
Resolve Terraform warnings

### DIFF
--- a/credentials/.terraform.lock.hcl
+++ b/credentials/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.4.0"
   hashes = [
     "h1:Bs7LAkV/iQTLv72j+cTMrvx2U3KyXrcVHaGbdns1NcE=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
     "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/local" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
@@ -42,6 +44,7 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.4"
   hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
     "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",

--- a/credentials/ssh_keygen.tf
+++ b/credentials/ssh_keygen.tf
@@ -3,15 +3,14 @@ resource "tls_private_key" "key" {
   algorithm = "RSA"
 }
 
-resource "local_file" "private_key" {
-  filename          = local.ssh_private_key_filename
-  sensitive_content = tls_private_key.key.private_key_openssh
-  file_permission   = "0600"
+resource "local_sensitive_file" "private_key" {
+  filename        = local.ssh_private_key_filename
+  content         = tls_private_key.key.private_key_openssh
+  file_permission = "0600"
 }
 
-resource "local_file" "public_key" {
-  filename          = local.ssh_public_key_filename
-  sensitive_content = tls_private_key.key.public_key_openssh
-  file_permission   = "0644"
+resource "local_sensitive_file" "public_key" {
+  filename        = local.ssh_public_key_filename
+  content         = tls_private_key.key.public_key_openssh
+  file_permission = "0644"
 }
-


### PR DESCRIPTION
In `configure/ssh_keygen.tf`: use `local_sensitive_file` with `content` attribute instead of `local_file` with `sensitive_content`. 

Fixes #58