### PR TITLE
Resolve Ansible warnings

### DIFF
--- a/configure/playbooks/roles/docker/tasks/main.yml
+++ b/configure/playbooks/roles/docker/tasks/main.yml
@@ -61,7 +61,7 @@
   notify: reload docker
 
 - name: Generate container server certificate
-  include: create_docker_server_cert.yml
+  import_tasks: create_docker_server_cert.yml
   notify: restart docker
 
 - name: "Ensure docker service configuraiton is reloaded before restarting the service"

--- a/configure/playbooks/roles/provision/tasks/main.yml
+++ b/configure/playbooks/roles/provision/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: "Update packages"
-  include: package_update.yml
+  import_tasks: package_update.yml
 
 - name: "Set locale"
-  include: locale.yml
+  import_tasks: locale.yml
 
 - name: "Mount EFS volume"
   ansible.builtin.include_tasks: "mount_efs.yml"

--- a/configure/playbooks/roles/tomcat/tasks/main.yml
+++ b/configure/playbooks/roles/tomcat/tasks/main.yml
@@ -58,7 +58,7 @@
   failed_when: false
 
 - name: Upgrade/install Tomcat if needed
-  include: tasks/upgrade.yml
+  import_tasks: tasks/upgrade.yml
   when: "not tomcat_check.stat.exists or tomcat_version not in tomcat_check_version.stdout"
 
 - name: Copy tomcat service file

--- a/configure/playbooks/roles/xnat/tasks/main.yml
+++ b/configure/playbooks/roles/xnat/tasks/main.yml
@@ -10,24 +10,24 @@
     state: installed
 
 - name: "Configure XNAT directories"
-  include: directories.yml
+  import_tasks: directories.yml
 
 - name: "Add or upgrade XNAT code"
-  include: upgrade_xnat.yml
+  import_tasks: upgrade_xnat.yml
 
 - name: "Add or upgrade plugins"
-  include: plugins.yml
+  import_tasks: plugins.yml
 
 - name: "Add or upgrade pipeline installer"
-  include: pipelines.yml
+  import_tasks: pipelines.yml
   when: pipeline_engine_enabled
 
 - name: "Configure XNAT settings files"
-  include: settings_files.yml
+  import_tasks: settings_files.yml
 
 - name: "Configure LDAP for XNAT"
-  include: ldap.yml
+  import_tasks: ldap.yml
   when: ldap.enabled
 
 - name: "XNAT site configuration"
-  include: configure.yml
+  import_tasks: configure.yml


### PR DESCRIPTION
Replace deprecated `include` with `import_tasks`.

Fixes #61