### PR TITLE
Increase proxy timeout settings for nginx

### DIFF
--- a/configure/playbooks/roles/nginx/templates/nginx.j2
+++ b/configure/playbooks/roles/nginx/templates/nginx.j2
@@ -129,9 +129,9 @@ http {
             proxy_set_header X-Forwarded-Proto  $scheme;
             proxy_set_header X-Forwarded-Port   $remote_port;
             proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
-            proxy_connect_timeout               600;
-            proxy_send_timeout                  600;
-            proxy_read_timeout                  600;
+            proxy_connect_timeout               3600;
+            proxy_send_timeout                  3600;
+            proxy_read_timeout                  3600;
             proxy_buffers                       4 32k;
             client_max_body_size                0;
             client_body_buffer_size             128k;


### PR DESCRIPTION
Avoid `Gateway Timeout` errors when uploading large files by increasing the `proxy_*_timeout` settings from 10 to 60 minutes.

Fixes #65.