### PR TITLE
Increase root block device size for the web and container services

### DIFF
--- a/provision/main.tf
+++ b/provision/main.tf
@@ -73,10 +73,8 @@ module "web_server" {
     "main"      = var.ec2_instance_types["xnat_web"]
     "container" = var.ec2_instance_types["xnat_cserv"]
   }
-  root_block_device_size = {
-    "main"      = var.root_block_device_size["xnat_web"]
-    "container" = var.root_block_device_size["xnat_cserv"]
-  }
+
+  root_block_device_size = var.root_block_device_size
 
   vpc_id            = module.setup_vpc.vpc_id
   ami               = module.get_ami.amis[var.instance_os]

--- a/provision/modules/database/vars.tf
+++ b/provision/modules/database/vars.tf
@@ -19,12 +19,6 @@ variable "instance_type" {
   }
 }
 
-variable "root_block_device_size" {
-  type        = string
-  description = "Storage space on the root block device (GB)"
-  default     = 30
-}
-
 variable "availability_zone" {
   type        = string
   description = "The AZ to use for the EC2 instance"

--- a/provision/modules/web-server/vars.tf
+++ b/provision/modules/web-server/vars.tf
@@ -31,7 +31,7 @@ variable "root_block_device_size" {
   description = "Storage space on the root block device (GB)"
   default = {
     "main"      = 30
-    "container" = 10
+    "container" = 30
   }
 }
 

--- a/provision/modules/web-server/vars.tf
+++ b/provision/modules/web-server/vars.tf
@@ -27,12 +27,9 @@ variable "instance_types" {
 }
 
 variable "root_block_device_size" {
-  type        = map(any)
+  type        = number
   description = "Storage space on the root block device (GB)"
-  default = {
-    "main"      = 30
-    "container" = 30
-  }
+  default     = 30
 }
 
 variable "availability_zone" {

--- a/provision/modules/web-server/web-server.tf
+++ b/provision/modules/web-server/web-server.tf
@@ -23,7 +23,7 @@ resource "aws_instance" "servers" {
   vpc_security_group_ids = [aws_security_group.sg[each.key].id]
 
   root_block_device {
-    volume_size = var.root_block_device_size[each.key]
+    volume_size = var.root_block_device_size
   }
 
   tags = {

--- a/provision/terraform.tfvars_sample
+++ b/provision/terraform.tfvars_sample
@@ -30,8 +30,8 @@ ec2_instance_types = {
 
 # EC2 root block device volume size
 root_block_device_size = {
-  "xnat_web"   = 10
-  "xnat_cserv" = 10
+  "xnat_web"   = 30
+  "xnat_cserv" = 30
 }
 
 # EC2 instance OS - this will be used to determine:

--- a/provision/terraform.tfvars_sample
+++ b/provision/terraform.tfvars_sample
@@ -29,10 +29,7 @@ ec2_instance_types = {
 }
 
 # EC2 root block device volume size
-root_block_device_size = {
-  "xnat_web"   = 30
-  "xnat_cserv" = 30
-}
+root_block_device_size = 30
 
 # EC2 instance OS - this will be used to determine:
 # - which AMI to use

--- a/provision/terraform.tfvars_sample
+++ b/provision/terraform.tfvars_sample
@@ -31,7 +31,6 @@ ec2_instance_types = {
 # EC2 root block device volume size
 root_block_device_size = {
   "xnat_web"   = 10
-  "xnat_db"    = 10
   "xnat_cserv" = 10
 }
 

--- a/provision/vars.tf
+++ b/provision/vars.tf
@@ -75,12 +75,9 @@ variable "ec2_instance_types" {
 
 # EC2 root block device volume size
 variable "root_block_device_size" {
-  type        = map(any)
+  type        = number
   description = "Storage space on the root block device (GB)"
-  default = {
-    "xnat_web"   = 30
-    "xnat_cserv" = 30
-  }
+  default     = 30
 }
 
 # EC2 instance OS

--- a/provision/vars.tf
+++ b/provision/vars.tf
@@ -79,7 +79,6 @@ variable "root_block_device_size" {
   description = "Storage space on the root block device (GB)"
   default = {
     "xnat_web"   = 10
-    "xnat_db"    = 10
     "xnat_cserv" = 10
   }
 }

--- a/provision/vars.tf
+++ b/provision/vars.tf
@@ -78,8 +78,8 @@ variable "root_block_device_size" {
   type        = map(any)
   description = "Storage space on the root block device (GB)"
   default = {
-    "xnat_web"   = 10
-    "xnat_cserv" = 10
+    "xnat_web"   = 30
+    "xnat_cserv" = 30
   }
 }
 


### PR DESCRIPTION
- Remove `root_block_device_size["xnat_db"]` as it is unused
- Increase the default root block device size to 30 GB for both the container and web servers
- Use the same root block device size for both web and container servers by replacing the `map`-type variable with a single number and using it for both instances

Fixes #67.