### PR TITLE
Add check to verify that AWS instances are running

### DIFF
--- a/configure/playbooks/install_container_service.yml
+++ b/configure/playbooks/install_container_service.yml
@@ -1,6 +1,13 @@
 ---
 # Set up the Container Service on the hosts
 # The client configuration is done in `install_xnat.yml`
+- name: Wait until instance is running
+  hosts: cserv_hosts
+  gather_facts: false
+
+  roles:
+    - { role: wait_until_running }
+
 - name: Provision container service host
   hosts: cserv_hosts
   become: true

--- a/configure/playbooks/install_xnat.yml
+++ b/configure/playbooks/install_xnat.yml
@@ -1,4 +1,11 @@
 ---
+- name: Wait until instance is running
+  hosts: web
+  gather_facts: false
+
+  roles:
+    - { role: wait_until_running }
+
 - name: Install dependencies
   hosts: web
   become: true

--- a/configure/playbooks/roles/wait_until_running/tasks/main.yml
+++ b/configure/playbooks/roles/wait_until_running/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Wait until AWS instance is running
+  ansible.builtin.wait_for_connection:
+    delay: 5
+    timeout: 600
+    sleep: 5
+    connect_timeout: 5


### PR DESCRIPTION
Use `ansible.built_in.wait_for_connection` to delay the Ansible playbooks until the EC2 instances are up and running.

Fixes #60