### PR TITLE
Use EC2 instance with more memory for container service

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ terraform destroy
 
 This is assuming usage of 50 hours per week (10 hours per day times 5 days per week) with the following resources:
   - web server: t3.large
-  - Container Service server: t3.large
+  - Container Service server: m4.xlarge
   - database server: db.t3.medium
   - up to 20 GB EFS storage
 

--- a/configure/group_vars/web/vars/tomcat.yml
+++ b/configure/group_vars/web/vars/tomcat.yml
@@ -25,5 +25,5 @@ tomcat:
 # You may want to increase the heap space if you have enough RAM available
 java_mem:
   Xms: "512M"
-  Xmx: "4G"
+  Xmx: "16G"
   MetaspaceSize: "300M"

--- a/configure/playbooks/roles/container_service_client/files/defaced-recon-all-command.json
+++ b/configure/playbooks/roles/container_service_client/files/defaced-recon-all-command.json
@@ -215,7 +215,7 @@
       }
     ],
     "reserve-memory": 4096,
-    "limit-memory": 16384,
+    "limit-memory": 14336,
     "limit-cpu": 4,
     "container-labels": {},
     "generic-resources": {},

--- a/configure/playbooks/roles/container_service_client/files/defaced-recon-all-command.json
+++ b/configure/playbooks/roles/container_service_client/files/defaced-recon-all-command.json
@@ -214,9 +214,9 @@
         ]
       }
     ],
-    "reserve-memory": 2048,
-    "limit-memory": 4096,
-    "limit-cpu": 2,
+    "reserve-memory": 4096,
+    "limit-memory": 16384,
+    "limit-cpu": 4,
     "container-labels": {},
     "generic-resources": {},
     "ulimits": {}

--- a/configure/playbooks/roles/container_service_client/files/defaced-recon-all-gpu-command.json
+++ b/configure/playbooks/roles/container_service_client/files/defaced-recon-all-gpu-command.json
@@ -215,9 +215,9 @@
         ]
       }
     ],
-    "reserve-memory": 2048,
-    "limit-memory": 4096,
-    "limit-cpu": 2,
+    "reserve-memory": 4096,
+    "limit-memory": 16384,
+    "limit-cpu": 4,
     "container-labels": {},
     "generic-resources": {},
     "ulimits": {}

--- a/configure/playbooks/roles/container_service_client/files/defaced-recon-all-gpu-command.json
+++ b/configure/playbooks/roles/container_service_client/files/defaced-recon-all-gpu-command.json
@@ -216,7 +216,7 @@
       }
     ],
     "reserve-memory": 4096,
-    "limit-memory": 16384,
+    "limit-memory": 14336,
     "limit-cpu": 4,
     "container-labels": {},
     "generic-resources": {},

--- a/configure/playbooks/roles/container_service_client/files/recon-all-command.json
+++ b/configure/playbooks/roles/container_service_client/files/recon-all-command.json
@@ -215,7 +215,7 @@
     }
   ],
   "reserve-memory": 4096,
-  "limit-memory": 16384,
+  "limit-memory": 14336,
   "limit-cpu": 4,
   "container-labels": {},
   "generic-resources": {},

--- a/configure/playbooks/roles/container_service_client/files/recon-all-command.json
+++ b/configure/playbooks/roles/container_service_client/files/recon-all-command.json
@@ -214,9 +214,9 @@
       ]
     }
   ],
-  "reserve-memory": 2048,
-  "limit-memory": 4096,
-  "limit-cpu": 2,
+  "reserve-memory": 4096,
+  "limit-memory": 16384,
+  "limit-cpu": 4,
   "container-labels": {},
   "generic-resources": {},
   "ulimits": {}

--- a/configure/playbooks/roles/container_service_client/files/recon-all-gpu-command.json
+++ b/configure/playbooks/roles/container_service_client/files/recon-all-gpu-command.json
@@ -216,7 +216,7 @@
     }
   ],
   "reserve-memory": 4096,
-  "limit-memory": 16384,
+  "limit-memory": 14336,
   "limit-cpu": 4,
   "container-labels": {},
   "generic-resources": {},

--- a/configure/playbooks/roles/container_service_client/files/recon-all-gpu-command.json
+++ b/configure/playbooks/roles/container_service_client/files/recon-all-gpu-command.json
@@ -215,9 +215,9 @@
       ]
     }
   ],
-  "reserve-memory": 2048,
-  "limit-memory": 4096,
-  "limit-cpu": 2,
+  "reserve-memory": 4096,
+  "limit-memory": 16384,
+  "limit-cpu": 4,
   "container-labels": {},
   "generic-resources": {},
   "ulimits": {}

--- a/provision/README.md
+++ b/provision/README.md
@@ -162,7 +162,7 @@ terraform destroy
 |------|-------------|------|---------|:--------:|
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | AZs to use for deploying XNAT | `list(string)` | <pre>[<br>  "eu-west-2a",<br>  "eu-west-2b"<br>]</pre> | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region to use for deploying XNAT | `string` | `"eu-west-2"` | no |
-| <a name="input_ec2_instance_types"></a> [ec2\_instance\_types](#input\_ec2\_instance\_types) | Instance type to use for each server | `map(any)` | <pre>{<br>  "xnat_cserv": "t3.large",<br>  "xnat_db": "db.t3.large",<br>  "xnat_web": "t3.large"<br>}</pre> | no |
+| <a name="input_ec2_instance_types"></a> [ec2\_instance\_types](#input\_ec2\_instance\_types) | Instance type to use for each server | `map(any)` | <pre>{<br>  "xnat_cserv": "m4.xlarge",<br>  "xnat_db": "db.t3.large",<br>  "xnat_web": "t3.large"<br>}</pre> | no |
 | <a name="input_extend_http_cidr"></a> [extend\_http\_cidr](#input\_extend\_http\_cidr) | The CIDR blocks to grant HTTP access to the web server, in addition to your own IP address | `list(string)` | `[]` | no |
 | <a name="input_extend_https_cidr"></a> [extend\_https\_cidr](#input\_extend\_https\_cidr) | The CIDR blocks to grant HTTSP access to the web server, in addition to your own IP address | `list(string)` | `[]` | no |
 | <a name="input_extend_ssh_cidr"></a> [extend\_ssh\_cidr](#input\_extend\_ssh\_cidr) | CIDR blocks servers should permit SHH access from, in addition to your own IP address | `list(string)` | `[]` | no |

--- a/provision/README.md
+++ b/provision/README.md
@@ -16,15 +16,18 @@ The Terraform scripts will create the following infrastructure on AWS:
 
 ### Instance types
 
-The smallest instance types (`t2.nano`) do not provide enough RAM for running XNAT. We have found that we need to use `t3.large` instances for the Container Service and database, and `t3.large` instances for the web server, to prevent the site from crashing when uploading data or running containers.
+The smallest instance types (`t2.nano`) do not provide enough RAM for running XNAT. We have found
+that we need to use a `db.t3.medium` instance the database, a `m4.xlarge` instance for the container
+service, and a `t3.large` instance for the web server, to prevent the site from crashing when
+uploading data or running containers.
 
 You can change the instance type used by setting `ec2_instance_type` in your `xnat-aws/provision/terraform.tfvars` file, e.g.:
 
 ```terraform
 ec2_instance_types = {
   "xnat_web"   = "t3.large"
-  "xnat_db"    = "db.t3.large"
-  "xnat_cserv" = "t3.large"
+  "xnat_db"    = "db.t3.medium"
+  "xnat_cserv" = "m4.xlarge"
 }
 ```
 

--- a/provision/modules/web-server/vars.tf
+++ b/provision/modules/web-server/vars.tf
@@ -22,7 +22,7 @@ variable "instance_types" {
   description = "The instance type to use for the EC2 instances"
   default = {
     "main"      = "t3.large"
-    "container" = "t3.large"
+    "container" = "m4.xlarge"
   }
 }
 

--- a/provision/terraform.tfvars_sample
+++ b/provision/terraform.tfvars_sample
@@ -25,7 +25,7 @@ extend_https_cidr = []
 ec2_instance_types = {
   "xnat_web"   = "t3.large"    # XNAT needs more RAM than available in t2.micro
   "xnat_db"    = "db.t3.medium" # XNAT needs more RAM than available in t2.micro
-  "xnat_cserv" = "t3.large"
+  "xnat_cserv" = "m4.xlarge"
 }
 
 # EC2 root block device volume size

--- a/provision/vars.tf
+++ b/provision/vars.tf
@@ -69,7 +69,7 @@ variable "ec2_instance_types" {
   default = {
     "xnat_web"   = "t3.large"
     "xnat_db"    = "db.t3.large"
-    "xnat_cserv" = "t3.large"
+    "xnat_cserv" = "m4.xlarge"
   }
 }
 


### PR DESCRIPTION
- Use `m4.xlarge` by default for container service (fixes #75)
- Increase memory limits for `tomcat` and the Docker images (fixes #74)

It's possible that these limits are a little overkill, but they allow the FastSurfer analysis to complete successfully and might be necessary when multiple users will be active.