### PR TITLE
Add instance scheduler

### DIFF
--- a/provision/.terraform.lock.hcl
+++ b/provision/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.4.0"
+  constraints = ">= 2.3.0"
+  hashes = [
+    "h1:cJokkjeH1jfpG4QEHdRx0t2j8rr52H33A7C/oX73Ok4=",
+    "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
+    "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
+    "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
+    "zh:70dae36c176aa2b258331ad366a471176417a94dd3b4985a911b8be9ff842b00",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d8c8e3925f1e21daf73f85983894fbe8868e326910e6df3720265bc657b9c9c",
+    "zh:a032ec0f0aee27a789726e348e8ad20778c3a1c9190ef25e7cff602c8d175f44",
+    "zh:b8e50de62ba185745b0fe9713755079ad0e9f7ac8638d204de6762cc36870410",
+    "zh:c8ad0c7697a3d444df21ff97f3473a8604c8639be64afe3f31b8ec7ad7571e18",
+    "zh:df736c5a2a7c3a82c5493665f659437a22f0baf8c2d157e45f4dd7ca40e739fc",
+    "zh:e8ffbf578a0977074f6d08aa8734e36c726e53dc79894cfc4f25fadc4f45f1df",
+    "zh:efea57ff23b141551f92b2699024d356c7ffd1a4ad62931da7ed7a386aef7f1f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.14.0"
   constraints = ">= 4.45.0, >= 5.0.0"

--- a/provision/README.md
+++ b/provision/README.md
@@ -165,6 +165,7 @@ to skip the prompt.
 | <a name="module_get_ami"></a> [get\_ami](#module\_get\_ami) | ./modules/get_ami | n/a |
 | <a name="module_get_my_ip"></a> [get\_my\_ip](#module\_get\_my\_ip) | ./modules/get_my_ip | n/a |
 | <a name="module_setup_vpc"></a> [setup\_vpc](#module\_setup\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_stop_scheduler"></a> [stop\_scheduler](#module\_stop\_scheduler) | diodonfrost/lambda-scheduler-stop-start/aws | n/a |
 | <a name="module_web_server"></a> [web\_server](#module\_web\_server) | ./modules/web-server | n/a |
 
 ## Resources
@@ -192,6 +193,7 @@ to skip the prompt.
 | <a name="input_instance_os"></a> [instance\_os](#input\_instance\_os) | OS to use for the instance - will determine the AMI to use | `string` | `"rocky9"` | no |
 | <a name="input_instance_private_ips"></a> [instance\_private\_ips](#input\_instance\_private\_ips) | Private IP addresses for each instance | `map(any)` | <pre>{<br>  "xnat_cserv": "192.168.56.14",<br>  "xnat_web": "192.168.56.10"<br>}</pre> | no |
 | <a name="input_root_block_device_size"></a> [root\_block\_device\_size](#input\_root\_block\_device\_size) | Storage space on the root block device (GB) | `number` | `30` | no |
+| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | cron expression to determine when the EC2 and RDS instances are scheduled to stop. | `string` | `"cron(0 0 18 * * *)"` | no |
 | <a name="input_smtp_private_ip"></a> [smtp\_private\_ip](#input\_smtp\_private\_ip) | Private IP address to use to the SMTP mail server | `string` | `"192.168.56.101"` | no |
 | <a name="input_subnet_cidr_blocks"></a> [subnet\_cidr\_blocks](#input\_subnet\_cidr\_blocks) | CIDR block for the VPC and subnets | `map(any)` | <pre>{<br>  "private": [<br>    "192.168.100.0/24",<br>    "192.168.101.0/24"<br>  ],<br>  "public": [<br>    "192.168.56.0/24"<br>  ]<br>}</pre> | no |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | CIDR block for the VPC | `string` | `"192.168.0.0/16"` | no |

--- a/provision/main.tf
+++ b/provision/main.tf
@@ -91,6 +91,7 @@ module "web_server" {
   ssh_cidr          = concat([module.get_my_ip.my_public_cidr], var.extend_ssh_cidr)
   http_cidr         = concat([module.get_my_ip.my_public_cidr], var.extend_http_cidr)
   https_cidr        = concat([module.get_my_ip.my_public_cidr], var.extend_https_cidr)
+  scheduled         = true
 }
 
 # Create EFS
@@ -113,6 +114,7 @@ module "database" {
   availability_zone = var.availability_zones[0]
   subnet_ids        = module.setup_vpc.private_subnets
   webserver_sg_id   = module.web_server.webserver_sg_id
+  scheduled         = true
 }
 
 # Appstream

--- a/provision/main.tf
+++ b/provision/main.tf
@@ -177,6 +177,21 @@ resource "local_file" "ansible-hosts" {
   file_permission = "0644"
 }
 
+# Instance scheduler; automatically stop the EC2 and RDS instances every day at 6pm
+module "stop_scheduler" {
+  source                         = "diodonfrost/lambda-scheduler-stop-start/aws"
+  name                           = "ec2_stop"
+  cloudwatch_schedule_expression = var.schedule_expression
+  schedule_action                = "stop"
+  ec2_schedule                   = "true"
+  rds_schedule                   = "true"
+
+  scheduler_tag = {
+    key   = "scheduled"
+    value = "true"
+  }
+}
+
 locals {
   # AWS
   ssh_key_name             = "aws-rsa"

--- a/provision/modules/database/database.tf
+++ b/provision/modules/database/database.tf
@@ -3,7 +3,7 @@ resource "aws_db_subnet_group" "xnat-db" {
   subnet_ids = var.subnet_ids
 
   tags = {
-    Name = var.name
+    Name      = var.name
     scheduled = var.scheduled
   }
 }

--- a/provision/modules/database/database.tf
+++ b/provision/modules/database/database.tf
@@ -4,6 +4,7 @@ resource "aws_db_subnet_group" "xnat-db" {
 
   tags = {
     Name = var.name
+    scheduled = var.scheduled
   }
 }
 

--- a/provision/modules/database/vars.tf
+++ b/provision/modules/database/vars.tf
@@ -34,3 +34,9 @@ variable "webserver_sg_id" {
   type        = string
   description = "The ID of the security group for the web server. To allow access to the database from the web server only."
 }
+
+variable "scheduled" {
+  type        = bool
+  description = "Whether to schedule the instance to stop and start automatically"
+  default     = false
+}

--- a/provision/modules/web-server/vars.tf
+++ b/provision/modules/web-server/vars.tf
@@ -67,3 +67,9 @@ variable "https_cidr" {
   type        = list(string)
   description = "The CIDR block to grant HTTSP access to the web server"
 }
+
+variable "scheduled" {
+  type        = bool
+  description = "Whether to schedule the instance to stop and start automatically"
+  default     = false
+}

--- a/provision/modules/web-server/web-server.tf
+++ b/provision/modules/web-server/web-server.tf
@@ -27,7 +27,8 @@ resource "aws_instance" "servers" {
   }
 
   tags = {
-    Name = var.names[each.key]
+    Name      = var.names[each.key]
+    scheduled = var.scheduled
   }
 }
 

--- a/provision/terraform.tfvars_sample
+++ b/provision/terraform.tfvars_sample
@@ -40,3 +40,6 @@ instance_os = "rocky9"
 as2_image_name           = "IDEAS-FSL-AmazonLinux2-EFSMount-2023-08-31"
 as2_instance_type        = "stream.standard.medium"
 as2_desired_instance_num = 1
+
+# Scheduler
+schedule_expression = "cron(0 0 18 * * *)"

--- a/provision/vars.tf
+++ b/provision/vars.tf
@@ -114,3 +114,9 @@ variable "as2_image_name" {
   description = "Name of the AppStream image"
   default     = "IDEAS-FSL-AmazonLinux2-EFSMount-2023-08-30"
 }
+
+variable "schedule_expression" {
+  type        = string
+  description = "cron expression to determine when the EC2 and RDS instances are scheduled to stop."
+  default     = "cron(0 0 18 * * *)" # 6pm evrery day
+}


### PR DESCRIPTION
- Automatically stop EC2 and RDS instance according to a `cron` schedule
- The default is to stop the instances every day at 18:00

Fixes #84