### PR TITLE
Fixes for integrating updated ansible collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ data
 
 .vscode
 
+terraform.tfstate
+**/.terraform/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ data
 
 .vscode
 
-terraform.tfstate
-**/.terraform/*

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ To destroy the infrastructure, go to the `xnat-aws/provision` directory and type
 terraform destroy
 ```
 
+If this command is interrupted i.e. you lose internet connection when running locally, you may find that you can no longer run `terraform destroy` successfully.
+Therefore you need to manually delete some resources in the AWS console, but you can encounter errors when attempting to delete certain resources:
+`The vpc 'vpc-id' has dependencies and cannot be deleted.` or
+`Network interface is currently in use and is of type "interface".`
+
+To find the remaining VPC dependencies, go to the `xnat-aws/provision` directory and type:
+
+```bash
+    ./show_resources_to_delete.sh
+```
+
+N.B. You need to add your `VPC ID` and `region` to the `show_resources_to_delete.sh` script.
+
+After deleting the dependiences you can retry deleting your VPC and/or Network interface - [see more info](https://repost.aws/knowledge-center/troubleshoot-dependency-error-delete-vpc).
+
 ## AWS cost estimate
 
 [It is estimated](provision/aws-cost-estimate.pdf) the AWS resources will cost approximately **$270

--- a/configure/playbooks/group_vars/xnat.yml
+++ b/configure/playbooks/group_vars/xnat.yml
@@ -53,9 +53,10 @@ ldap_ca_cert_file_on_client: "{{ xnat.install_downloads }}/certs/ldap-ca.cert"
 # mirsg.infrastructure.nginx
 nginx_use_ssl: "{{ ssl.use_ssl }}"
 nginx_server_name: "{{ web_server.host }}"
-nginx_upstream_port: 8104
+nginx_upstream_port: 104
 nginx_upstream_listen_port: 8104
 nginx_proxy_port: 8080 # tomcat
 nginx_root: /usr/share/tomcat/webapps/ROOT
 nginx_app_access_log: "{{ nginx_log_folder }}/xnat.access.log"
 nginx_app_error_log: "{{ nginx_log_folder }}/xnat.error.log"
+nginx_conf_template: nginx_reverse_proxy_aws.j2

--- a/configure/playbooks/roles/requirements.yml
+++ b/configure/playbooks/roles/requirements.yml
@@ -5,4 +5,4 @@ collections:
   - name: mirsg.infrastructure
     type: git
     source: https://github.com/UCL-MIRSG/ansible-collection-infra.git
-    version: 1.20.0
+    version: 1.22.0

--- a/configure/playbooks/roles/setup_xnat_project/tasks/upload_data.yml
+++ b/configure/playbooks/roles/setup_xnat_project/tasks/upload_data.yml
@@ -1,3 +1,8 @@
+- name: Remove python3-requests
+  ansible.builtin.yum:
+    name: python3-requests
+    state: absent
+
 - name: "Install necessary Python dependencies on host"
   ansible.builtin.pip:
     name:

--- a/configure/playbooks/templates/nginx_reverse_proxy_aws.j2
+++ b/configure/playbooks/templates/nginx_reverse_proxy_aws.j2
@@ -1,0 +1,150 @@
+# Configure a reverse proxy
+# Optionally create an additional default_server
+load_module '/usr/lib64/nginx/modules/ngx_stream_module.so';
+user nginx;
+worker_processes auto;
+error_log {{ nginx_error_log }} warn;
+pid /run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+{% if nginx_upstream_port is defined and nginx_upstream_listen_port is defined %}
+stream {
+    upstream backend {
+        server localhost:{{ nginx_upstream_port }};
+    }
+
+    server {
+        listen {{ nginx_upstream_listen_port }};
+        proxy_pass backend;
+    }
+}
+{% endif %}
+
+http {
+    server_names_hash_bucket_size  128;
+    sendfile            off;
+#    sendfile            on; can cause a problem in VirtualBox
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+    default_type        application/octet-stream;
+    access_log          {{ nginx_access_log }};
+
+    # Good security practice is not to expose nginx version
+    server_tokens off;
+
+    # Compress responses to reduce network traffic. Note this may affect performance
+    gzip on;
+    gzip_disable "msie6";
+
+{% if nginx_use_ssl %}
+    # SSL parameters must be specified outside of the server block.
+    # Otherwise may only use the nginx may end up using parameters specified in
+    # the default_server block even if a different serer is matched
+
+    ssl_certificate {{ nginx_ssl_cert_file }};
+    ssl_certificate_key {{ nginx_ssl_key_file }};
+
+    # TLS 1.0 and TLS 1.1 should be disabled
+    # TLS 1.3 may not be supported by Centos7
+    ssl_protocols TLSv1.2;
+
+    ssl_dhparam {{ nginx_dh_params_file }};
+    ssl_ecdh_curve secp384r1;
+
+    # Increase the cache lifetime to improve performance; this requires a larger cache size
+    ssl_session_cache shared:SSL:40m;
+    ssl_session_timeout 4h;
+
+    # Configure ciphers
+    ssl_prefer_server_ciphers on;
+
+    # Mozilla intermediate compatibility for TLS1.2
+    ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384s";
+
+    # Enable HSTS - this requests browsers to only contact the server using TLS
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
+{% endif %}
+
+
+    # Default server block for connections that do not match the expected host names.
+    # Note that nginx only uses server_name for disambiguation purposes; if
+    # there is no matching server_name then nginx will use the default_server
+    # regardless of its value of server_name
+{% if nginx_add_default_server %}
+    server {
+        listen 80 default_server;
+    {% if nginx_use_ssl %}
+        listen 443 ssl default_server;
+    {% endif %}
+
+    {% if nginx_ipv6_enabled %}
+        listen [::]:80 default_server;
+        {% if nginx_use_ssl %}
+        listen [::]:443 ssl default_server;
+        {% endif %}
+    {% endif %}
+
+        server_name _;
+
+        return 444;
+    }
+{% endif %}
+
+{% if nginx_use_ssl %}
+    # Redirect to https
+    server {
+        listen {{ nginx_http_port }};
+
+        server_name {{ nginx_server_name }};
+        return 301 https://{{ nginx_server_name }}:{{ nginx_https_port }}$request_uri;
+    }
+{% endif %}
+
+    server {
+
+{% if nginx_use_ssl %}
+        listen {{ nginx_https_port }} ssl http2{% if not nginx_add_default_server %} default_server{% endif %};
+    {% if nginx_ipv6_enabled %}
+        listen [::]:{{ nginx_https_port }} ssl http2{% if not nginx_add_default_server %} default_server{% endif %};
+    {% endif %}
+{% else %}
+        listen {{ nginx_http_port }}{% if not nginx_add_default_server %} default_server{% endif %};
+    {% if nginx_ipv6_enabled %}
+        listen [::]:{{ nginx_http_port }}{% if not nginx_add_default_server %} default_server{% endif %};
+    {% endif %}
+{% endif %}
+
+        # Note: server_name is only used for disambiguation
+        server_name     {{ nginx_server_name }};
+
+        {% if nginx_root is defined %}
+        root            {{ nginx_root }};
+        {% endif %}
+
+        location / {
+            proxy_pass                          http://localhost:{{ nginx_proxy_port }};
+            proxy_redirect                      http:// $scheme://;
+            proxy_set_header Host               $http_host;
+            proxy_set_header X-Real-IP          $remote_addr;
+            proxy_set_header X-Forwarded-Host   $http_host;
+            proxy_set_header X-Forwarded-Proto  $scheme;
+            proxy_set_header X-Forwarded-Port   $remote_port;
+            proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_connect_timeout               600;
+            proxy_send_timeout                  600;
+            proxy_read_timeout                  600;
+            proxy_buffers                       4 32k;
+            client_max_body_size                0;
+            client_body_buffer_size             128k;
+            proxy_max_temp_file_size            0;
+        }
+        access_log {{ nginx_app_access_log }};
+        error_log {{ nginx_app_error_log }};
+    }
+}

--- a/provision/.terraform.lock.hcl
+++ b/provision/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.45.0, >= 5.30.0"
   hashes = [
     "h1:LEJSEOCO8LPIO6uxJDYrFXdr+Y9hSmTWVcSgG6EdGvw=",
+    "h1:ucZxfJtHMHBp4Amnk0K3Bdr7Umbk6he8byey/+u41Lc=",
     "zh:22c4599d47cd59e5519c52afc528fa2aec43b4434f369870ee2806daa071449d",
     "zh:3c2edc482662a654f84db4cd3f2cdd8f200147207d053d2e95082744b7814e6d",
     "zh:57edc36f908c64de37e92a978f3d675604315a725268da936fcd1e270199db47",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/http" {
   version = "3.4.2"
   hashes = [
     "h1:v6Hn+15SfN2SI281Sp+uNXdWhD197ycP07fnaoGpPcc=",
+    "h1:vaoPfsLm6mOk6avKTrWi35o+9p4fEeZAY3hzYoXVTfo=",
     "zh:0ba051c9c8659ce0fec94a3d50926745f11759509c4d6de0ad5f5eb289f0edd9",
     "zh:23e6760e8406fef645913bf47bfab1ca984c1c5805d2bb0ef8310b16913d29cd",
     "zh:3c69fde4548bfe65b968534c4df8d699648c921d6a065b97fec5faece73a442b",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/http" {
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.1"
   hashes = [
+    "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
     "h1:tjcGlQAFA0kmQ4vKkIPPUC4it1UYxLbg4YvHOWRAJHA=",
     "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
     "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
@@ -66,6 +69,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.2"
   hashes = [
     "h1:R5qdQjKzOU16TziCN1vR3Exr/B+8WGK80glLTT4ZCPk=",
+    "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
     "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
     "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
     "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",

--- a/provision/README.md
+++ b/provision/README.md
@@ -156,13 +156,15 @@ to skip the prompt.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.30.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.14.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.52.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.1 |
 
 ## Modules
 

--- a/provision/show_resources_to_delete.sh
+++ b/provision/show_resources_to_delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+vpc="vpc-xxxxxxxxxxxxx"
+region="eu-west-2"
+aws ec2 describe-internet-gateways --region $region --filters 'Name=attachment.vpc-id,Values='$vpc | grep InternetGatewayId
+aws ec2 describe-subnets --region $region --filters 'Name=vpc-id,Values='$vpc | grep SubnetId
+aws ec2 describe-route-tables --region $region --filters 'Name=vpc-id,Values='$vpc | grep RouteTableId
+aws ec2 describe-network-acls --region $region --filters 'Name=vpc-id,Values='$vpc | grep NetworkAclId
+aws ec2 describe-vpc-peering-connections --region $region --filters 'Name=requester-vpc-info.vpc-id,Values='$vpc | grep VpcPeeringConnectionId
+aws ec2 describe-vpc-endpoints --region $region --filters 'Name=vpc-id,Values='$vpc | grep VpcEndpointId
+aws ec2 describe-nat-gateways --region $region --filter 'Name=vpc-id,Values='$vpc | grep NatGatewayId
+aws ec2 describe-security-groups --region $region --filters 'Name=vpc-id,Values='$vpc | grep GroupId
+aws ec2 describe-instances --region $region --filters 'Name=vpc-id,Values='$vpc | grep InstanceId
+aws ec2 describe-vpn-connections --region $region --filters 'Name=vpc-id,Values='$vpc | grep VpnConnectionId
+aws ec2 describe-vpn-gateways --region $region --filters 'Name=attachment.vpc-id,Values='$vpc | grep VpnGatewayId
+aws ec2 describe-network-interfaces --region $region --filters 'Name=vpc-id,Values='$vpc | grep NetworkInterfaceId
+aws ec2 describe-carrier-gateways --region $region --filters Name=vpc-id,Values=$vpc | grep CarrierGatewayId
+aws ec2 describe-local-gateway-route-table-vpc-associations --region $region --filters Name=vpc-id,Values=$vpc | grep LocalGatewayRouteTableVpcAssociationId

--- a/provision/templates/ansible_hosts.yml.tftpl
+++ b/provision/templates/ansible_hosts.yml.tftpl
@@ -34,7 +34,7 @@ all:
         xnat_web:
 
     # xnat_cserv hosts and all the clients (web servers) it serves
-    xnat_container_service:
+    container_service:
       hosts:
         xnat_cserv:
         xnat_web:

--- a/provision/versions.tf
+++ b/provision/versions.tf
@@ -1,0 +1,11 @@
+# Enforce minimum Terraform and provider version numbers.
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30.0"
+    }
+  }
+
+  required_version = ">= 1.1.4"
+}


### PR DESCRIPTION
This PR was deployed on the [arc-playpen-collaborations](https://ucl-cloud.awsapps.com/start/#/) and moves towards integrating the [updated ansible collection version 1.22.0](https://github.com/UCL-MIRSG/ansible-collection-infra) into this repo.

Merge into `use-mirsg-infra-collection` branch before merging into `main`

Changes in this PR:
- Added `./show_resources_to_delete.sh` script to find VPC dependencies for manual deletion if `terraform destroy` command has been interrupted when deploying locally 
- `configure/playbooks/group_vars/xnat.yml` nginx_upstream_port changed which addresses [this issue in this repo at least](https://github.com/UCL-MIRSG/ansible-collection-infra/issues/119)
- `configure/playbooks/roles/setup_xnat_project/tasks/upload_data.yml` task added to remove python3-requests library before installing necessary Python dependencies on host
- `configure/playbooks/templates/nginx_reverse_proxy_aws.j2` was added to fix nginx error caused by aws url being long
- Changed group from `xnat_container_service` to `container_service` in `provision/templates/ansible_hosts.yml.tftpl` to match playbook names